### PR TITLE
Fix upload overwrite issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,8 +70,17 @@ def upload_images():
     
     for file in files:
         if file.filename and file:
-            filename = secure_filename(file.filename)
+            original_name = secure_filename(file.filename)
+            filename = original_name
             save_path = os.path.join(UPLOAD_DIR, filename)
+            name, ext = os.path.splitext(original_name)
+            counter = 1
+            # Ensure unique filenames to avoid overwriting existing uploads
+            while os.path.exists(save_path):
+                filename = f"{name}_{counter}{ext}"
+                save_path = os.path.join(UPLOAD_DIR, filename)
+                counter += 1
+
             file.save(save_path)
             executor.submit(create_single_thumbnail, save_path)
             uploaded_filenames.append(filename)


### PR DESCRIPTION
## Summary
- ensure uploaded filenames are unique to avoid overwriting existing files

## Testing
- `python -m py_compile app.py start.py diptych_creator.py`


------
https://chatgpt.com/codex/tasks/task_e_68803f6850b8832298bdcb8b032f8317