### PR TITLE
Update diptych gap behavior

### DIFF
--- a/diptych_creator.py
+++ b/diptych_creator.py
@@ -67,9 +67,12 @@ def create_diptych_canvas(img1, img2, final_dims, gap_px, outer_border_px=0, bor
     half_w = final_width // 2 if is_landscape_diptych else final_width
     half_h = final_height if is_landscape_diptych else final_height // 2
 
+    # Use gap only when both images are present
+    effective_gap = gap_px if img1 and img2 else 0
+
     # Calculate canvas size including outer border
-    canvas_w = final_width + gap_px + 2 * outer_border_px if is_landscape_diptych else final_width + 2 * outer_border_px
-    canvas_h = final_height + 2 * outer_border_px if is_landscape_diptych else final_height + gap_px + 2 * outer_border_px
+    canvas_w = final_width + effective_gap + 2 * outer_border_px if is_landscape_diptych else final_width + 2 * outer_border_px
+    canvas_h = final_height + 2 * outer_border_px if is_landscape_diptych else final_height + effective_gap + 2 * outer_border_px
     canvas = Image.new('RGB', (canvas_w, canvas_h), border_color)
 
     # Center images in their cells
@@ -81,7 +84,7 @@ def create_diptych_canvas(img1, img2, final_dims, gap_px, outer_border_px=0, bor
             canvas.paste(img1, (x1, y1))
         # Right image
         if img2:
-            x2 = outer_border_px + half_w + gap_px + (half_w - img2.width) // 2
+            x2 = outer_border_px + half_w + effective_gap + (half_w - img2.width) // 2
             y2 = outer_border_px + (half_h - img2.height) // 2
             canvas.paste(img2, (x2, y2))
     else:
@@ -93,7 +96,7 @@ def create_diptych_canvas(img1, img2, final_dims, gap_px, outer_border_px=0, bor
         # Bottom image
         if img2:
             x2 = outer_border_px + (half_w - img2.width) // 2
-            y2 = outer_border_px + half_h + gap_px + (half_h - img2.height) // 2
+            y2 = outer_border_px + half_h + effective_gap + (half_h - img2.height) // 2
             canvas.paste(img2, (x2, y2))
     return canvas
 

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -1,0 +1,28 @@
+import pytest
+from PIL import Image
+from diptych_creator import create_diptych_canvas
+
+def make_img(w=50, h=50, color='white'):
+    return Image.new('RGB', (w, h), color)
+
+def test_landscape_gap_used_when_both_images():
+    img1 = make_img()
+    img2 = make_img()
+    canvas = create_diptych_canvas(img1, img2, (100, 50), gap_px=10)
+    assert canvas.size == (110, 50)
+
+def test_landscape_no_gap_when_missing_image():
+    img1 = make_img()
+    canvas = create_diptych_canvas(img1, None, (100, 50), gap_px=10)
+    assert canvas.size == (100, 50)
+
+def test_portrait_gap_used_when_both_images():
+    img1 = make_img()
+    img2 = make_img()
+    canvas = create_diptych_canvas(img1, img2, (50, 100), gap_px=10)
+    assert canvas.size == (50, 110)
+
+def test_portrait_no_gap_when_missing_image():
+    img = make_img()
+    canvas = create_diptych_canvas(None, img, (50, 100), gap_px=10)
+    assert canvas.size == (50, 100)


### PR DESCRIPTION
## Summary
- avoid applying a gap when only one image is provided
- add regression tests for the gap logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68804209cdbc83228df7fbadb7da0c38