### PR TITLE
Add unit tests for diptych utilities

### DIFF
--- a/diptych_creator.py
+++ b/diptych_creator.py
@@ -67,9 +67,12 @@ def create_diptych_canvas(img1, img2, final_dims, gap_px, outer_border_px=0, bor
     half_w = final_width // 2 if is_landscape_diptych else final_width
     half_h = final_height if is_landscape_diptych else final_height // 2
 
+    # Use no gap when one of the images is missing
+    actual_gap = gap_px if img1 is not None and img2 is not None else 0
+
     # Calculate canvas size including outer border
-    canvas_w = final_width + gap_px + 2 * outer_border_px if is_landscape_diptych else final_width + 2 * outer_border_px
-    canvas_h = final_height + 2 * outer_border_px if is_landscape_diptych else final_height + gap_px + 2 * outer_border_px
+    canvas_w = final_width + actual_gap + 2 * outer_border_px if is_landscape_diptych else final_width + 2 * outer_border_px
+    canvas_h = final_height + 2 * outer_border_px if is_landscape_diptych else final_height + actual_gap + 2 * outer_border_px
     canvas = Image.new('RGB', (canvas_w, canvas_h), border_color)
 
     # Center images in their cells

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+import types
+
+
+def load_module():
+    if 'diptych_creator' in sys.modules:
+        return sys.modules['diptych_creator']
+
+    # Create a minimal PIL stub
+    pil = types.ModuleType('PIL')
+
+    class FakeImage:
+        def __init__(self, size, color='white'):
+            self.width, self.height = size
+            self.size = size
+
+        @classmethod
+        def new(cls, mode, size, color='white'):
+            return cls(size, color)
+
+        def paste(self, img, box):
+            pass
+
+    pil.Image = types.SimpleNamespace(new=FakeImage.new, Resampling=types.SimpleNamespace(LANCZOS=1))
+    pil.ExifTags = types.SimpleNamespace(TAGS={'Orientation': 274})
+
+    sys.modules['PIL'] = pil
+    sys.modules['PIL.Image'] = pil.Image
+    sys.modules['PIL.ExifTags'] = pil.ExifTags
+
+    return importlib.import_module('diptych_creator')
+
+
+def test_calculate_pixel_dimensions():
+    mod = load_module()
+    assert mod.calculate_pixel_dimensions(8.5, 11, 300) == (2550, 3300)
+
+
+def test_create_diptych_canvas_no_gap_with_missing_image():
+    mod = load_module()
+    img1 = mod.Image.new('RGB', (100, 100), 'white')
+    canvas = mod.create_diptych_canvas(img1, None, (300, 200), 50)
+    assert canvas.size == (300, 200)


### PR DESCRIPTION
## Summary
- add a minimal `tests` package
- test `calculate_pixel_dimensions`
- verify no gap is added when a diptych side is missing
- adjust `create_diptych_canvas` to support the no-gap behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880421540ec8322ae6cada3ae22d72a