### PR TITLE
Enhance UI with auto pairing

### DIFF
--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -36,6 +36,7 @@
                 <h1 class="text-lg font-bold tracking-tight">Diptych Master</h1>
             </div>
             <div class="flex items-center gap-2">
+                <button id="auto-pair-btn" class="btn btn-secondary"><span class="truncate">Auto Pair</span></button>
                 <button id="download-btn" class="btn btn-primary"><span class="truncate">Download All</span></button>
                 <button id="mobile-menu-btn" class="icon-btn md:hidden"></button>
             </div>


### PR DESCRIPTION
## Summary
- add a Flask route that groups uploaded images into pairs based on capture time
- include helper for extracting timestamps from EXIF
- expose an Auto Pair button in the UI and wire it up in JS
- implement `autoPairImages` client side to call the new route

## Testing
- `python -m py_compile app.py diptych_creator.py start.py`

------
https://chatgpt.com/codex/tasks/task_e_688042c9bdc48322aa99c91420c4e221