### PR TITLE
Fix main canvas background for clarity

### DIFF
--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -50,7 +50,7 @@
             </aside>
 
             <div class="flex-1 flex flex-col items-center justify-center p-4 sm:p-6 md:p-8 bg-gray-50 relative">
-                <div id="main-canvas" class="w-full max-w-2xl bg-white rounded-xl shadow-2xl border border-[var(--border-color)] overflow-hidden relative">
+                <div id="main-canvas" class="w-full max-w-2xl rounded-xl shadow-2xl border border-[var(--border-color)] overflow-hidden relative">
                     <img id="preview-image" class="absolute inset-0 w-full h-full object-cover hidden" alt="Diptych Preview">
                     <div id="canvas-grid" class="absolute inset-0 grid grid-cols-2 h-full">
                         <div class="drop-zone" data-slot="1"></div>


### PR DESCRIPTION
## Summary
- remove white background from the diptych preview container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ef8d13148322a76e0d1df5dd96cb