### PR TITLE
Improve image pool with used images section

### DIFF
--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -16,7 +16,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const welcomeScreen = document.getElementById('welcome-screen');
     const appContainer = document.getElementById('app-container');
     const imagePool = document.getElementById('image-pool');
+    const usedImagePool = document.getElementById('used-image-pool');
     const unpairedCount = document.getElementById('unpaired-count');
+    const usedCount = document.getElementById('used-count');
     const mainCanvas = document.getElementById('main-canvas');
     const previewImage = document.getElementById('preview-image');
     const canvasGrid = document.getElementById('canvas-grid');
@@ -260,10 +262,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- RENDERING ---
     function renderImagePool() {
         imagePool.innerHTML = '';
+        usedImagePool.innerHTML = '';
         const usedPaths = appState.diptychs.flatMap(d => [d.image1?.path, d.image2?.path]).filter(Boolean);
-        const unpairedImages = appState.images.filter(img => !usedPaths.includes(img.path));
-        unpairedCount.textContent = unpairedImages.length;
-        unpairedImages.forEach(imgData => {
+        const unusedImages = appState.images.filter(img => !usedPaths.includes(img.path));
+        const usedImages = appState.images.filter(img => usedPaths.includes(img.path));
+        unpairedCount.textContent = unusedImages.length;
+        usedCount.textContent = usedImages.length;
+
+        function createThumb(imgData) {
             const thumbContainer = document.createElement('div');
             thumbContainer.className = 'img-thumbnail thumbnail-loading';
             thumbContainer.dataset.path = imgData.path;
@@ -275,8 +281,11 @@ document.addEventListener('DOMContentLoaded', () => {
             filenameDiv.className = 'filename';
             filenameDiv.textContent = imgData.path;
             thumbContainer.append(imgEl, filenameDiv);
-            imagePool.appendChild(thumbContainer);
-        });
+            return thumbContainer;
+        }
+
+        unusedImages.forEach(imgData => imagePool.appendChild(createThumb(imgData)));
+        usedImages.forEach(imgData => usedImagePool.appendChild(createThumb(imgData)));
     }
 
     function renderActiveDiptychUI() {
@@ -454,6 +463,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (activeDiptych) {
                     const imageKey = `image${slot}`;
                     activeDiptych[imageKey] = { path };
+                    renderImagePool();
                     renderActiveDiptychUI();
                     requestPreviewRefresh();
                 }

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -44,9 +44,15 @@
 
         <main class="flex flex-1 flex-col md:flex-row overflow-y-auto">
             <aside id="left-panel" class="w-full md:w-72 border-b md:border-b-0 md:border-r border-[var(--accent-color)] p-4 space-y-4 hidden md:flex flex-col">
-                <h2 class="text-lg font-semibold mb-3">Your Images (<span id="unpaired-count">0</span>)</h2>
-                <div id="image-pool" class="grid grid-cols-3 md:grid-cols-2 gap-3 overflow-y-auto flex-1"></div>
+                <div>
+                    <h2 class="text-lg font-semibold mb-3">Your Images (<span id="unpaired-count">0</span>)</h2>
+                    <div id="image-pool" class="grid grid-cols-3 md:grid-cols-2 gap-3 overflow-y-auto flex-1"></div>
+                </div>
                 <button id="upload-more-btn" class="btn btn-secondary w-full mt-4"><svg class="mr-2" fill="none" height="16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" x2="12" y1="3" y2="15"></line></svg>Upload More</button>
+                <div id="used-images-section">
+                    <h2 class="text-lg font-semibold mt-4 mb-3">Used Images (<span id="used-count">0</span>)</h2>
+                    <div id="used-image-pool" class="grid grid-cols-3 md:grid-cols-2 gap-3 overflow-y-auto"></div>
+                </div>
             </aside>
 
             <div class="flex-1 flex flex-col items-center justify-center p-4 sm:p-6 md:p-8 bg-gray-50 relative">


### PR DESCRIPTION
## Summary
- show used images in their own section under the library
- update JS to populate both unused and used lists
- refresh the image lists after dropping onto a diptych

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f05468d88322939e448604bf146d