### PR TITLE
Auto rotate images for diptych cells

### DIFF
--- a/diptych_creator.py
+++ b/diptych_creator.py
@@ -25,7 +25,7 @@ def apply_exif_orientation(img):
         pass
     return img
 
-def process_source_image(image_path, target_diptych_dims, rotation_override=0, fit_mode='fill'):
+def process_source_image(image_path, target_diptych_dims, rotation_override=0, fit_mode='fill', auto_rotate=True):
     try:
         with Image.open(image_path) as img:
             img = apply_exif_orientation(img)
@@ -34,9 +34,16 @@ def process_source_image(image_path, target_diptych_dims, rotation_override=0, f
 
             diptych_w, diptych_h = target_diptych_dims
             is_landscape_diptych = diptych_w > diptych_h
-            
+
             half_w = diptych_w // 2 if is_landscape_diptych else diptych_w
             half_h = diptych_h if is_landscape_diptych else diptych_h // 2
+
+            if auto_rotate and half_w != half_h:
+                cell_landscape = half_w > half_h
+                img_landscape = img.width > img.height
+                if cell_landscape != img_landscape:
+                    img = img.rotate(90, expand=True)
+
             target_aspect = half_w / half_h
             
             if fit_mode == 'fill':

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -9,7 +9,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from diptych_creator import create_diptych_canvas
+from diptych_creator import create_diptych_canvas, process_source_image
 
 def make_img(w=50, h=50, color='white'):
     return Image.new('RGB', (w, h), color)
@@ -35,3 +35,17 @@ def test_portrait_no_gap_when_missing_image():
     img = make_img()
     canvas = create_diptych_canvas(None, img, (50, 100), gap_px=10)
     assert canvas.size == (50, 100)
+
+
+def test_auto_rotate_landscape_into_portrait_cell(tmp_path):
+    path = tmp_path / "landscape.jpg"
+    Image.new('RGB', (100, 50), 'blue').save(path)
+    result = process_source_image(str(path), (100, 80))
+    assert result.size == (50, 80)
+
+
+def test_auto_rotate_portrait_into_landscape_cell(tmp_path):
+    path = tmp_path / "portrait.jpg"
+    Image.new('RGB', (50, 100), 'red').save(path)
+    result = process_source_image(str(path), (80, 100))
+    assert result.size == (80, 50)


### PR DESCRIPTION
## Summary
- auto rotate images in `process_source_image` when orientation doesn't match the diptych cell
- test auto rotation logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f098a9c88322afbc7307e7a34da6