### PR TITLE
Fix preview canvas colors

### DIFF
--- a/app.py
+++ b/app.py
@@ -184,7 +184,9 @@ def get_wysiwyg_preview():
                     path1,
                     final_dims,
                     image1_data.get('rotation', 0),
-                    config.get('fit_mode', 'fill')
+                    config.get('fit_mode', 'fill'),
+                    True,
+                    border_color
                 )
 
         if image2_data:
@@ -194,7 +196,9 @@ def get_wysiwyg_preview():
                     path2,
                     final_dims,
                     image2_data.get('rotation', 0),
-                    config.get('fit_mode', 'fill')
+                    config.get('fit_mode', 'fill'),
+                    True,
+                    border_color
                 )
 
         if not img1 and not img2:

--- a/diptych_creator.py
+++ b/diptych_creator.py
@@ -25,7 +25,8 @@ def apply_exif_orientation(img):
         pass
     return img
 
-def process_source_image(image_path, target_diptych_dims, rotation_override=0, fit_mode='fill', auto_rotate=True):
+def process_source_image(image_path, target_diptych_dims, rotation_override=0,
+                        fit_mode='fill', auto_rotate=True, border_color='white'):
     try:
         with Image.open(image_path) as img:
             img = apply_exif_orientation(img)
@@ -59,7 +60,7 @@ def process_source_image(image_path, target_diptych_dims, rotation_override=0, f
                 return img.resize((half_w, half_h), Image.Resampling.LANCZOS)
             else:
                 img.thumbnail((half_w, half_h), Image.Resampling.LANCZOS)
-                background = Image.new('RGB', (half_w, half_h), 'white')
+                background = Image.new('RGB', (half_w, half_h), border_color)
                 paste_x = (half_w - img.width) // 2
                 paste_y = (half_h - img.height) // 2
                 background.paste(img, (paste_x, paste_y))
@@ -109,8 +110,14 @@ def create_diptych_canvas(img1, img2, final_dims, gap_px, outer_border_px=0, bor
 
 def create_diptych(image_data1, image_data2, output_path, final_dims, gap_px, fit_mode, dpi, outer_border_px=0, border_color='white'):
     """Processes two source images and saves the resulting diptych with correct DPI and outer border."""
-    img1 = process_source_image(image_data1['path'], final_dims, image_data1.get('rotation', 0), fit_mode)
-    img2 = process_source_image(image_data2['path'], final_dims, image_data2.get('rotation', 0), fit_mode)
+    img1 = process_source_image(
+        image_data1['path'], final_dims,
+        image_data1.get('rotation', 0), fit_mode,
+        True, border_color)
+    img2 = process_source_image(
+        image_data2['path'], final_dims,
+        image_data2.get('rotation', 0), fit_mode,
+        True, border_color)
     if not img1 or not img2:
         print(f"Skipping diptych due to image processing error.")
         return

--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -312,6 +312,16 @@ document.addEventListener('DOMContentLoaded', () => {
         outerBorderSizeSlider.value = config.outer_border;
         outerBorderSizeValue.textContent = `${config.outer_border} px`;
         borderColorInput.value = config.border_color;
+
+        // Update preview and UI colors
+        document.documentElement.style.setProperty('--border-color', config.border_color);
+        mainCanvas.style.backgroundColor = config.border_color;
+        previewImage.style.backgroundColor = config.border_color;
+
+        // Ensure canvas aspect ratio matches output
+        const aspectW = config.orientation === 'portrait' ? config.height : config.width;
+        const aspectH = config.orientation === 'portrait' ? config.width : config.height;
+        mainCanvas.style.aspectRatio = `${aspectW}/${aspectH}`;
         
         orientationBtn.innerHTML = config.orientation === 'landscape' 
             ? `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="12" rx="2" ry="2"></rect></svg>` 


### PR DESCRIPTION
## Summary
- fill letterboxing with border color
- propagate border color through preview generation
- sync preview aspect ratio and border colors on the frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688185196a248322b08bdc0b8d731199