### PR TITLE
Add diptych delete and update defaults

### DIFF
--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -276,6 +276,25 @@
 .diptych-tray-preview.active .diptych-tray-number {
     background-color: var(--primary-color);
 }
+.delete-diptych-btn {
+    position: absolute;
+    top: -0.5rem;
+    left: -0.5rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    background-color: var(--accent-color);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+.delete-diptych-btn:hover {
+    background-color: #ef4444;
+    color: white;
+}
 .add-diptych-btn {
     width: 7rem;
     height: 4rem;

--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -142,7 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function addNewDiptych(andSwitch = true) {
-        let baseConfig = { fit_mode: 'fill', gap: 25, width: 10, height: 8, orientation: 'landscape', dpi: 300, outer_border: 0, border_color: '#ffffff' };
+        let baseConfig = { fit_mode: 'fit', gap: 20, width: 6, height: 4, orientation: 'landscape', dpi: 300, outer_border: 20, border_color: '#ffffff' };
         if (appState.diptychs.length > 0) {
             baseConfig = { ...appState.diptychs[appState.activeDiptychIndex].config };
         }
@@ -165,12 +165,25 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function deleteDiptych(index) {
+        if (appState.diptychs.length <= 1) return;
+        if (index >= 0 && index < appState.diptychs.length) {
+            appState.diptychs.splice(index, 1);
+            if (appState.activeDiptychIndex >= appState.diptychs.length) {
+                appState.activeDiptychIndex = appState.diptychs.length - 1;
+            }
+            renderDiptychTray();
+            renderImagePool();
+            renderActiveDiptychUI();
+        }
+    }
+
     async function autoPairImages() {
         if (appState.images.length === 0) return;
         showLoading('Pairing images...');
         try {
             appState.diptychs = [];
-            const defaultConfig = { fit_mode: 'fill', gap: 25, width: 10, height: 8, orientation: 'landscape', dpi: 300, outer_border: 0, border_color: '#ffffff' };
+            const defaultConfig = { fit_mode: 'fit', gap: 20, width: 6, height: 4, orientation: 'landscape', dpi: 300, outer_border: 20, border_color: '#ffffff' };
             for (let i = 0; i < appState.images.length; i += 2) {
                 const img1 = appState.images[i] ? { ...appState.images[i] } : null;
                 const img2 = appState.images[i + 1] ? { ...appState.images[i + 1] } : null;
@@ -255,6 +268,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     function handleTrayClick(e) {
+        if (e.target.closest('.delete-diptych-btn')) {
+            const item = e.target.closest('.diptych-tray-item');
+            if (item) deleteDiptych(parseInt(item.dataset.index, 10));
+            return;
+        }
         const item = e.target.closest('.diptych-tray-item');
         if (item) switchActiveDiptych(parseInt(item.dataset.index, 10));
         else if (e.target.closest('.add-diptych-btn')) addNewDiptych();
@@ -341,7 +359,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const number = document.createElement('span');
             number.className = 'diptych-tray-number';
             number.textContent = index + 1;
-            item.append(preview, number);
+            const delBtn = document.createElement('div');
+            delBtn.className = 'delete-diptych-btn';
+            delBtn.innerHTML = `<svg fill="currentColor" height="12" viewBox="0 0 256 256" width="12"><path d="M208.49,191.51a12,12,0,0,1-17,17L128,145,64.49,208.49a12,12,0,0,1-17-17L111,128,47.51,64.49a12,12,0,0,1,17-17L128,111l63.51-63.51a12,12,0,0,1,17,17L145,128Z"></path></svg>`;
+            item.append(preview, number, delBtn);
             diptychTray.appendChild(item);
             updateTrayPreview(preview, diptych);
         });

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -103,22 +103,22 @@
                             <label class="config-label" for="image-fitting">Image Fitting</label>
                             <select class="form-input-custom" id="image-fitting" name="image-fitting">
                                 <option value="fill">Crop / Fill</option>
-                                <option value="fit">Fit / Letterbox</option>
+                                <option value="fit">Fit (No Crop)</option>
                             </select>
                         </div>
                         <div>
                             <div class="flex items-center justify-between">
-                                <label class="config-label" for="border-size">Border Size</label>
-                                <p id="border-size-value" class="text-xs text-[var(--text-secondary)]">25 px</p>
+                                <label class="config-label" for="border-size">Image Spacing</label>
+                                <p id="border-size-value" class="text-xs text-[var(--text-secondary)]">20 px</p>
                             </div>
-                            <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="border-size" max="100" min="0" name="border-size" type="range" value="25"/>
+                            <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="border-size" max="100" min="0" name="border-size" type="range" value="20"/>
                         </div>
                         <div>
                             <div class="flex items-center justify-between">
                                 <label class="config-label" for="outer-border-size">Outer Border Size</label>
-                                <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">0 px</p>
+                                <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">20 px</p>
                             </div>
-                            <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="outer-border-size" max="100" min="0" name="outer-border-size" type="range" value="0"/>
+                            <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="outer-border-size" max="100" min="0" name="outer-border-size" type="range" value="20"/>
                         </div>
                         <div>
                             <label class="config-label" for="border-color">Border Color</label>


### PR DESCRIPTION
## Summary
- enable removal of diptychs from the tray
- rename Border Size to Image Spacing
- rename Fit/Letterbox option to Fit (No Crop)
- set default diptych settings (6x4 size, 300DPI, fit mode, 20px spacing and outer border)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818639d8cc8322b2d3a8388f7fd6e1