### PR TITLE
Fix preview border color rendering

### DIFF
--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -184,7 +184,7 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
-    background: white;
+    background: transparent;
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
 }

--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -229,6 +229,9 @@ document.addEventListener('DOMContentLoaded', () => {
         config.outer_border = parseInt(outerBorderSizeSlider.value, 10);
         outerBorderSizeValue.textContent = `${config.outer_border} px`;
         config.border_color = borderColorInput.value;
+        // Keep preview background in sync with selected border color
+        previewImage.style.backgroundColor = config.border_color;
+        mainCanvas.style.backgroundColor = config.border_color;
         
         // Update UI elements that depend on config changes
         renderActiveDiptychUI();
@@ -330,6 +333,9 @@ document.addEventListener('DOMContentLoaded', () => {
         outerBorderSizeSlider.value = config.outer_border;
         outerBorderSizeValue.textContent = `${config.outer_border} px`;
         borderColorInput.value = config.border_color;
+        // Sync preview background with current border color
+        previewImage.style.backgroundColor = config.border_color;
+        mainCanvas.style.backgroundColor = config.border_color;
         
         orientationBtn.innerHTML = config.orientation === 'landscape' 
             ? `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="12" rx="2" ry="2"></rect></svg>` 
@@ -393,6 +399,9 @@ document.addEventListener('DOMContentLoaded', () => {
             mainCanvas.classList.remove('preview-loading');
             return;
         }
+        // Ensure preview background matches outer border color
+        previewImage.style.backgroundColor = activeDiptych.config.border_color;
+        mainCanvas.style.backgroundColor = activeDiptych.config.border_color;
         try {
             mainCanvas.classList.add('preview-loading');
             const response = await fetch('/get_wysiwyg_preview', {


### PR DESCRIPTION
## Summary
- ensure the preview area background matches the chosen border color
- remove default white background from preview image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688191d2a67883228629c4554db237d1