### PR TITLE
Enhance grouping and JS usability

### DIFF
--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -227,10 +227,14 @@
     border-color: var(--primary-color);
     background-color: rgba(208, 19, 10, 0.1);
 }
+.drop-zone.drag-active {
+    outline: 2px dashed var(--primary-color);
+}
 .drop-zone.drag-over {
     background-color: rgba(208, 19, 10, 0.2);
     border-color: var(--primary-color);
     border-style: solid;
+    outline: 2px dashed var(--primary-color);
 }
 
 

--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -1,6 +1,6 @@
 // review_app/static/js/app.js
 
-document.addEventListener('DOMContentLoaded', () => {
+const DiptychApp = (() => {
     // --- STATE MANAGEMENT ---
     let appState = {
         images: [],
@@ -10,6 +10,10 @@ document.addEventListener('DOMContentLoaded', () => {
         isGenerating: false,
     };
     const PREVIEW_DEBOUNCE_DELAY = 300;
+
+    function pxToMm(px, dpi) {
+        return Math.round((px / dpi) * 25.4);
+    }
 
     // --- ELEMENT SELECTORS ---
     const fileUploader = document.getElementById('file-uploader');
@@ -225,9 +229,9 @@ document.addEventListener('DOMContentLoaded', () => {
         config.dpi = parseInt(outputDpiSelect.value, 10);
         config.fit_mode = imageFittingSelect.value;
         config.gap = parseInt(borderSizeSlider.value, 10);
-        borderSizeValue.textContent = `${config.gap} px`;
+        borderSizeValue.textContent = `${pxToMm(config.gap, config.dpi)} mm`;
         config.outer_border = parseInt(outerBorderSizeSlider.value, 10);
-        outerBorderSizeValue.textContent = `${config.outer_border} px`;
+        outerBorderSizeValue.textContent = `${pxToMm(config.outer_border, config.dpi)} mm`;
         config.border_color = borderColorInput.value;
         // Keep preview background in sync with selected border color
         previewImage.style.backgroundColor = config.border_color;
@@ -329,9 +333,9 @@ document.addEventListener('DOMContentLoaded', () => {
         outputDpiSelect.value = config.dpi;
         imageFittingSelect.value = config.fit_mode;
         borderSizeSlider.value = config.gap;
-        borderSizeValue.textContent = `${config.gap} px`;
+        borderSizeValue.textContent = `${pxToMm(config.gap, config.dpi)} mm`;
         outerBorderSizeSlider.value = config.outer_border;
-        outerBorderSizeValue.textContent = `${config.outer_border} px`;
+        outerBorderSizeValue.textContent = `${pxToMm(config.outer_border, config.dpi)} mm`;
         borderColorInput.value = config.border_color;
         // Sync preview background with current border color
         previewImage.style.backgroundColor = config.border_color;
@@ -465,12 +469,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 isDragging = true;
                 e.dataTransfer.setData('text/plain', thumbnail.dataset.path);
                 e.dataTransfer.effectAllowed = 'move';
+                dropZones.forEach(z => z.classList.add('drag-active'));
             }
         });
 
         document.addEventListener('dragend', () => {
             isDragging = false;
-            dropZones.forEach(zone => zone.classList.remove('drag-over'));
+            dropZones.forEach(zone => {
+                zone.classList.remove('drag-over');
+                zone.classList.remove('drag-active');
+            });
         });
 
         // Handle drop zone events
@@ -498,6 +506,7 @@ document.addEventListener('DOMContentLoaded', () => {
             zone.addEventListener('drop', (e) => {
                 e.preventDefault();
                 zone.classList.remove('drag-over');
+                zone.classList.remove('drag-active');
                 
                 const path = e.dataTransfer.getData('text/plain');
                 const slot = zone.dataset.slot;
@@ -584,5 +593,7 @@ document.addEventListener('DOMContentLoaded', () => {
         loadingOverlay.classList.add('hidden');
     }
 
-    init();
-});
+    return { init };
+})();
+
+document.addEventListener('DOMContentLoaded', () => DiptychApp.init());

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -109,14 +109,14 @@
                         <div>
                             <div class="flex items-center justify-between">
                                 <label class="config-label" for="border-size">Image Spacing</label>
-                                <p id="border-size-value" class="text-xs text-[var(--text-secondary)]">20 px</p>
+                                <p id="border-size-value" class="text-xs text-[var(--text-secondary)]">0 mm</p>
                             </div>
                             <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="border-size" max="100" min="0" name="border-size" type="range" value="20"/>
                         </div>
                         <div>
                             <div class="flex items-center justify-between">
                                 <label class="config-label" for="outer-border-size">Outer Border Size</label>
-                                <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">20 px</p>
+                                <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">0 mm</p>
                             </div>
                             <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="outer-border-size" max="100" min="0" name="outer-border-size" type="range" value="20"/>
                         </div>

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -10,6 +10,8 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from diptych_creator import create_diptych_canvas, process_source_image
+from app import get_capture_time, UPLOAD_TIMES
+from datetime import datetime
 
 def cell_size(final_dims, gap, outer=0, both=True):
     w, h = final_dims
@@ -64,3 +66,14 @@ def test_auto_rotate_portrait_into_landscape_cell(tmp_path):
     Image.new('RGB', (50, 100), 'red').save(path)
     result = process_source_image(str(path), (80, 100))
     assert result.size == (80, 50)
+
+
+def test_get_capture_time_falls_back_to_upload(tmp_path):
+    path = tmp_path / "sample.jpg"
+    Image.new('RGB', (10, 10), 'white').save(path)
+    UPLOAD_TIMES['sample.jpg'] = datetime(2021, 1, 1, 12, 0, 0)
+    try:
+        ts = get_capture_time(str(path))
+        assert ts == UPLOAD_TIMES['sample.jpg']
+    finally:
+        UPLOAD_TIMES.clear()


### PR DESCRIPTION
## Summary
- track upload times and use them in auto grouping when EXIF is missing
- wrap client script in a simple module and show spacing in mm
- highlight drop zones when dragging
- update labels in HTML for new units
- test fallback to upload time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cfd0c2948322ad35fab4057daa4c