### PR TITLE
Fix preview dimension calc and add coverage

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,9 +169,9 @@ def get_wysiwyg_preview():
         if not image1_data and not image2_data:
             return "No images to preview", 400
 
-        # Use a lower DPI for previews to make them generate faster
-        preview_dpi = 72
-        
+        # Use the requested DPI for consistency with the final output
+        preview_dpi = int(config.get('dpi', 72))
+
         # Handle orientation for the preview dimensions
         width = float(config.get('width', 10))
         height = float(config.get('height', 8))
@@ -183,31 +183,42 @@ def get_wysiwyg_preview():
         outer_border_px = int(config.get('outer_border', 0))
         border_color = config.get('border_color', 'white')
 
+        inner_w = final_dims[0] - 2 * outer_border_px
+        inner_h = final_dims[1] - 2 * outer_border_px
+        effective_gap = config.get('gap', 0)
+
+        if config.get('orientation') == 'portrait':
+            processing_dims = (inner_w, inner_h - effective_gap)
+        else:
+            processing_dims = (inner_w - effective_gap, inner_h)
+
         img1, img2 = None, None
         if image1_data:
             path1 = os.path.join(UPLOAD_DIR, secure_filename(os.path.basename(image1_data['path'])))
-            if os.path.exists(path1):
-                img1 = diptych_creator.process_source_image(
-                    path1,
-                    final_dims,
-                    image1_data.get('rotation', 0),
-                    config.get('fit_mode', 'fill')
-                )
+            if not os.path.exists(path1):
+                return jsonify({"error": f"Image not found: {image1_data['path']}"}), 404
+            img1 = diptych_creator.process_source_image(
+                path1,
+                processing_dims,
+                image1_data.get('rotation', 0),
+                config.get('fit_mode', 'fill')
+            )
 
         if image2_data:
             path2 = os.path.join(UPLOAD_DIR, secure_filename(os.path.basename(image2_data['path'])))
-            if os.path.exists(path2):
-                img2 = diptych_creator.process_source_image(
-                    path2,
-                    final_dims,
-                    image2_data.get('rotation', 0),
-                    config.get('fit_mode', 'fill')
-                )
+            if not os.path.exists(path2):
+                return jsonify({"error": f"Image not found: {image2_data['path']}"}), 404
+            img2 = diptych_creator.process_source_image(
+                path2,
+                processing_dims,
+                image2_data.get('rotation', 0),
+                config.get('fit_mode', 'fill')
+            )
 
         if not img1 and not img2:
             return "Error processing images", 500
 
-        canvas = diptych_creator.create_diptych_canvas(img1, img2, final_dims, config.get('gap', 0), outer_border_px, border_color)
+        canvas = diptych_creator.create_diptych_canvas(img1, img2, final_dims, effective_gap, outer_border_px, border_color)
         if not canvas:
             return "Error creating preview canvas", 500
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,86 @@
+import os
+import io
+from PIL import Image
+
+from app import app, UPLOAD_DIR
+from diptych_creator import (
+    calculate_pixel_dimensions,
+    process_source_image,
+    create_diptych_canvas,
+)
+
+
+def create_image(path, color):
+    Image.new('RGB', (20, 20), color).save(path)
+
+
+def test_preview_matches_final(tmp_path):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    img1_path = os.path.join(UPLOAD_DIR, 'a.jpg')
+    img2_path = os.path.join(UPLOAD_DIR, 'b.jpg')
+    create_image(img1_path, 'green')
+    create_image(img2_path, 'blue')
+
+    config = {
+        'width': 4,
+        'height': 3,
+        'dpi': 10,
+        'orientation': 'landscape',
+        'gap': 2,
+        'outer_border': 1,
+        'border_color': '#ff0000',
+        'fit_mode': 'fill'
+    }
+
+    diptych = {
+        'config': config,
+        'image1': {'path': img1_path},
+        'image2': {'path': img2_path}
+    }
+
+    with app.test_client() as client:
+        resp = client.post('/get_wysiwyg_preview', json={'diptych': diptych})
+        assert resp.status_code == 200
+        preview = Image.open(io.BytesIO(resp.data))
+
+    final_dims = calculate_pixel_dimensions(config['width'], config['height'], config['dpi'])
+    inner_w = final_dims[0] - 2 * config['outer_border']
+    inner_h = final_dims[1] - 2 * config['outer_border']
+    if config['orientation'] == 'portrait':
+        processing = (inner_w, inner_h - config['gap'])
+    else:
+        processing = (inner_w - config['gap'], inner_h)
+
+    img1 = process_source_image(img1_path, processing, 0, config['fit_mode'])
+    img2 = process_source_image(img2_path, processing, 0, config['fit_mode'])
+    final_canvas = create_diptych_canvas(
+        img1,
+        img2,
+        final_dims,
+        config['gap'],
+        config['outer_border'],
+        config['border_color']
+    )
+    buf = io.BytesIO()
+    final_canvas.save(buf, format='JPEG', quality=90)
+    buf.seek(0)
+    final_jpeg = Image.open(buf)
+
+    assert list(preview.getdata()) == list(final_jpeg.getdata())
+
+
+def test_preview_missing_file(tmp_path):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    img1_path = os.path.join(UPLOAD_DIR, 'c.jpg')
+    create_image(img1_path, 'red')
+
+    config = {'width': 4, 'height': 3, 'dpi': 10}
+    diptych = {
+        'config': config,
+        'image1': {'path': img1_path},
+        'image2': {'path': 'missing.jpg'}
+    }
+
+    with app.test_client() as client:
+        resp = client.post('/get_wysiwyg_preview', json={'diptych': diptych})
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- align preview calculation with final output to keep borders and gaps correct
- improve missing-file errors when generating preview
- add unit tests for preview accuracy and missing image handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d2fedeec8322a6d65f2d2e12a733