### PR TITLE
Enhance auto pairing by capture time

### DIFF
--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -227,10 +227,14 @@
     border-color: var(--primary-color);
     background-color: rgba(208, 19, 10, 0.1);
 }
+.drop-zone.drag-active {
+    outline: 2px dashed var(--primary-color);
+}
 .drop-zone.drag-over {
     background-color: rgba(208, 19, 10, 0.2);
     border-color: var(--primary-color);
     border-style: solid;
+    outline: 2px dashed var(--primary-color);
 }
 
 

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -109,14 +109,14 @@
                         <div>
                             <div class="flex items-center justify-between">
                                 <label class="config-label" for="border-size">Image Spacing</label>
-                                <p id="border-size-value" class="text-xs text-[var(--text-secondary)]">20 px</p>
+                                <p id="border-size-value" class="text-xs text-[var(--text-secondary)]">0 mm</p>
                             </div>
                             <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="border-size" max="100" min="0" name="border-size" type="range" value="20"/>
                         </div>
                         <div>
                             <div class="flex items-center justify-between">
                                 <label class="config-label" for="outer-border-size">Outer Border Size</label>
-                                <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">20 px</p>
+                                <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">0 mm</p>
                             </div>
                             <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="outer-border-size" max="100" min="0" name="outer-border-size" type="range" value="20"/>
                         </div>

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -10,6 +10,9 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from diptych_creator import create_diptych_canvas, process_source_image
+from app import get_capture_time, UPLOAD_TIMES
+import app as flask_app
+from datetime import datetime
 
 def cell_size(final_dims, gap, outer=0, both=True):
     w, h = final_dims
@@ -64,3 +67,44 @@ def test_auto_rotate_portrait_into_landscape_cell(tmp_path):
     Image.new('RGB', (50, 100), 'red').save(path)
     result = process_source_image(str(path), (80, 100))
     assert result.size == (80, 50)
+
+
+def test_get_capture_time_falls_back_to_upload(tmp_path):
+    path = tmp_path / "sample.jpg"
+    Image.new('RGB', (10, 10), 'white').save(path)
+    UPLOAD_TIMES['sample.jpg'] = datetime(2021, 1, 1, 12, 0, 0)
+    try:
+        ts = get_capture_time(str(path))
+        assert ts == UPLOAD_TIMES['sample.jpg']
+    finally:
+        UPLOAD_TIMES.clear()
+
+def test_auto_group_pairs_by_capture(tmp_path):
+    old_dir = flask_app.UPLOAD_DIR
+    flask_app.UPLOAD_DIR = str(tmp_path)
+    os.makedirs(flask_app.UPLOAD_DIR, exist_ok=True)
+    flask_app.UPLOAD_TIMES.clear()
+
+    dt1 = datetime(2021, 1, 1, 12, 0, 0)
+    dt2 = datetime(2021, 1, 1, 12, 0, 1)
+    exif_tag = flask_app.DATE_TAGS[0]
+    img = Image.new('RGB', (5, 5), 'white')
+    exif = Image.Exif()
+    exif[exif_tag] = dt1.strftime('%Y:%m:%d %H:%M:%S')
+    img.save(os.path.join(flask_app.UPLOAD_DIR, 'a1.jpg'), exif=exif)
+    exif = Image.Exif()
+    exif[exif_tag] = dt2.strftime('%Y:%m:%d %H:%M:%S')
+    img.save(os.path.join(flask_app.UPLOAD_DIR, 'a2.jpg'), exif=exif)
+
+    Image.new('RGB', (5, 5), 'white').save(os.path.join(flask_app.UPLOAD_DIR, 'b1.jpg'))
+    Image.new('RGB', (5, 5), 'white').save(os.path.join(flask_app.UPLOAD_DIR, 'b2.jpg'))
+    flask_app.UPLOAD_TIMES['b1.jpg'] = datetime(2021, 1, 2, 12, 0, 0)
+    flask_app.UPLOAD_TIMES['b2.jpg'] = datetime(2021, 1, 2, 12, 0, 1)
+
+    client = flask_app.app.test_client()
+    resp = client.post('/auto_group', json={'threshold': 2})
+    data = resp.get_json()
+    assert data['pairs'] == [['a1.jpg', 'a2.jpg'], ['b1.jpg', 'b2.jpg']]
+
+    flask_app.UPLOAD_DIR = old_dir
+    flask_app.UPLOAD_TIMES.clear()


### PR DESCRIPTION
## Summary
- call `/auto_group` endpoint from front-end to auto pair images
- fallback to upload time when EXIF DateTimeOriginal is missing
- add unit test for `/auto_group` capture-time grouping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cfd0c2948322ad35fab4057daa4c