### PR TITLE
Fix invalid svg namespaces

### DIFF
--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -19,7 +19,7 @@
     <div id="welcome-screen" class="absolute inset-0 z-50 flex flex-col items-center justify-center bg-white">
         <div class="text-center">
             <div class="inline-block text-[var(--primary-color)] mb-4">
-                <svg width="64" height="64" fill="none" viewBox="0 0 48 48" xmlns="[http://www.w3.org/2000/svg](http://www.w3.org/2000/svg)"><g clip-path="url(#clip0_welcome)"><path clip-rule="evenodd" d="M47.2426 24L24 47.2426L0.757355 24L24 0.757355L47.2426 24ZM12.2426 21H35.7574L24 9.24264L12.2426 21Z" fill="currentColor" fill-rule="evenodd"></path></g><defs><clipPath id="clip0_welcome"><rect fill="white" height="48" width="48"></rect></clipPath></defs></svg>
+                <svg width="64" height="64" fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_welcome)"><path clip-rule="evenodd" d="M47.2426 24L24 47.2426L0.757355 24L24 0.757355L47.2426 24ZM12.2426 21H35.7574L24 9.24264L12.2426 21Z" fill="currentColor" fill-rule="evenodd"></path></g><defs><clipPath id="clip0_welcome"><rect fill="white" height="48" width="48"></rect></clipPath></defs></svg>
             </div>
             <h1 class="text-4xl font-bold tracking-tighter">Diptych Master</h1>
             <p class="text-slate-600 mt-2">The professional way to create two-image layouts.</p>
@@ -32,7 +32,7 @@
     <div id="app-container" class="relative flex size-full min-h-screen flex-col overflow-hidden hidden">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-[var(--accent-color)] px-4 py-3 sm:px-6">
             <div class="flex items-center gap-3">
-                <div class="size-7 text-[var(--primary-color)]"><svg fill="none" viewBox="0 0 48 48" xmlns="[http://www.w3.org/2000/svg](http://www.w3.org/2000/svg)"><g clip-path="url(#clip0_header)"><path clip-rule="evenodd" d="M47.2426 24L24 47.2426L0.757355 24L24 0.757355L47.2426 24ZM12.2426 21H35.7574L24 9.24264L12.2426 21Z" fill="currentColor" fill-rule="evenodd"></path></g><defs><clipPath id="clip0_header"><rect fill="white" height="48" width="48"></rect></clipPath></defs></svg></div>
+                <div class="size-7 text-[var(--primary-color)]"><svg fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_header)"><path clip-rule="evenodd" d="M47.2426 24L24 47.2426L0.757355 24L24 0.757355L47.2426 24ZM12.2426 21H35.7574L24 9.24264L12.2426 21Z" fill="currentColor" fill-rule="evenodd"></path></g><defs><clipPath id="clip0_header"><rect fill="white" height="48" width="48"></rect></clipPath></defs></svg></div>
                 <h1 class="text-lg font-bold tracking-tight">Diptych Master</h1>
             </div>
             <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- correct SVG `xmlns` attributes so HTML renders without errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688abaabd2d08322884cb160133c96e3