### PR TITLE
Fix preview borders and fit background color

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,7 +201,9 @@ def get_wysiwyg_preview():
                 path1,
                 processing_dims,
                 image1_data.get('rotation', 0),
-                config.get('fit_mode', 'fill')
+                config.get('fit_mode', 'fill'),
+                True,
+                config.get('border_color', 'white')
             )
 
         if image2_data:
@@ -212,7 +214,9 @@ def get_wysiwyg_preview():
                 path2,
                 processing_dims,
                 image2_data.get('rotation', 0),
-                config.get('fit_mode', 'fill')
+                config.get('fit_mode', 'fill'),
+                True,
+                config.get('border_color', 'white')
             )
 
         if not img1 and not img2:

--- a/diptych_creator.py
+++ b/diptych_creator.py
@@ -25,7 +25,14 @@ def apply_exif_orientation(img):
         pass
     return img
 
-def process_source_image(image_path, target_diptych_dims, rotation_override=0, fit_mode='fill', auto_rotate=True):
+def process_source_image(
+    image_path,
+    target_diptych_dims,
+    rotation_override=0,
+    fit_mode='fill',
+    auto_rotate=True,
+    background_color='white',
+):
     try:
         with Image.open(image_path) as img:
             img = apply_exif_orientation(img)
@@ -59,7 +66,7 @@ def process_source_image(image_path, target_diptych_dims, rotation_override=0, f
                 return img.resize((half_w, half_h), Image.Resampling.LANCZOS)
             else:
                 img.thumbnail((half_w, half_h), Image.Resampling.LANCZOS)
-                background = Image.new('RGB', (half_w, half_h), 'white')
+                background = Image.new('RGB', (half_w, half_h), background_color)
                 paste_x = (half_w - img.width) // 2
                 paste_y = (half_h - img.height) // 2
                 background.paste(img, (paste_x, paste_y))
@@ -126,8 +133,22 @@ def create_diptych(image_data1, image_data2, output_path, final_dims, gap_px, fi
     else:
         processing_dims = (inner_w, inner_h - effective_gap)
 
-    img1 = process_source_image(image_data1['path'], processing_dims, image_data1.get('rotation', 0), fit_mode)
-    img2 = process_source_image(image_data2['path'], processing_dims, image_data2.get('rotation', 0), fit_mode)
+    img1 = process_source_image(
+        image_data1['path'],
+        processing_dims,
+        image_data1.get('rotation', 0),
+        fit_mode,
+        True,
+        border_color,
+    )
+    img2 = process_source_image(
+        image_data2['path'],
+        processing_dims,
+        image_data2.get('rotation', 0),
+        fit_mode,
+        True,
+        border_color,
+    )
     if not img1 or not img2:
         print(f"Skipping diptych due to image processing error.")
         return

--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -246,7 +246,7 @@
 .diptych-tray-preview {
     width: 7rem;
     height: 4rem;
-    border-radius: 0.375rem;
+    border-radius: 0;
     border: 2px solid var(--border-color);
     overflow: hidden;
     cursor: pointer;

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -56,7 +56,7 @@
             </aside>
 
             <div class="flex-1 flex flex-col items-center justify-center p-4 sm:p-6 md:p-8 bg-gray-50 relative">
-                <div id="main-canvas" class="w-full max-w-2xl rounded-xl shadow-2xl border border-[var(--border-color)] overflow-hidden relative">
+                <div id="main-canvas" class="w-full max-w-2xl shadow-2xl border border-[var(--border-color)] overflow-hidden relative">
                     <img id="preview-image" class="absolute inset-0 w-full h-full object-cover hidden" alt="Diptych Preview">
                     <div id="canvas-grid" class="absolute inset-0 grid grid-cols-2 h-full">
                         <div class="drop-zone" data-slot="1"></div>

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -77,3 +77,18 @@ def test_get_capture_time_falls_back_to_upload(tmp_path):
         assert ts == UPLOAD_TIMES['sample.jpg']
     finally:
         UPLOAD_TIMES.clear()
+
+
+def test_fit_mode_background_color(tmp_path):
+    path = tmp_path / "img.jpg"
+    Image.new('RGB', (10, 10), 'blue').save(path)
+    result = process_source_image(
+        str(path),
+        (40, 40),
+        rotation_override=0,
+        fit_mode='fit',
+        auto_rotate=False,
+        background_color='#ff0000',
+    )
+    assert result.getpixel((0, 0)) == (255, 0, 0)
+

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -84,3 +84,37 @@ def test_preview_missing_file(tmp_path):
     with app.test_client() as client:
         resp = client.post('/get_wysiwyg_preview', json={'diptych': diptych})
         assert resp.status_code == 404
+
+
+def test_preview_fit_background_color(tmp_path):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    img1_path = os.path.join(UPLOAD_DIR, 'd.jpg')
+    img2_path = os.path.join(UPLOAD_DIR, 'e.jpg')
+    create_image(img1_path, 'yellow')
+    create_image(img2_path, 'purple')
+
+    config = {
+        'width': 4,
+        'height': 3,
+        'dpi': 10,
+        'orientation': 'landscape',
+        'gap': 2,
+        'outer_border': 1,
+        'border_color': '#ff0000',
+        'fit_mode': 'fit'
+    }
+
+    diptych = {
+        'config': config,
+        'image1': {'path': img1_path},
+        'image2': {'path': img2_path}
+    }
+
+    with app.test_client() as client:
+        resp = client.post('/get_wysiwyg_preview', json={'diptych': diptych})
+        assert resp.status_code == 200
+        preview = Image.open(io.BytesIO(resp.data))
+
+    r, g, b = preview.getpixel((0, 0))
+    assert r > 240 and g < 30 and b < 30
+


### PR DESCRIPTION
## Summary
- ensure whitespace in fit mode uses the border color
- pass border color through to image processing
- remove rounded corners from previews
- update CSS for tray previews
- add regression tests for fit-mode background color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e213e1e483229f099cbcb419741c