### PR TITLE
Add orientation-aware previews

### DIFF
--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -242,8 +242,6 @@
     flex-shrink: 0;
 }
 .diptych-tray-preview {
-    width: 7rem;
-    height: 4rem;
     border-radius: 0;
     border: 2px solid var(--border-color);
     overflow: hidden;
@@ -252,6 +250,18 @@
     background-color: var(--secondary-color);
     background-size: cover;
     background-position: center;
+}
+
+/* Landscape orientation preview */
+.diptych-tray-preview.landscape {
+    width: 7rem;
+    height: 4rem;
+}
+
+/* Portrait orientation preview */
+.diptych-tray-preview.portrait {
+    width: 4rem;
+    height: 7rem;
 }
 .diptych-tray-preview:hover {
     border-color: #9ca3af;

--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -289,6 +289,7 @@ const DiptychApp = (() => {
         activeDiptych.config.orientation = activeDiptych.config.orientation === 'landscape' ? 'portrait' : 'landscape';
         renderActiveDiptychUI();
         updateActiveTrayPreview();
+        requestPreviewRefresh();
     }
 
     function handleRotate(e) {
@@ -513,6 +514,8 @@ const DiptychApp = (() => {
             if(element) element.style.backgroundImage = 'none';
             return;
         }
+        element.classList.toggle('portrait', diptych.config.orientation === 'portrait');
+        element.classList.toggle('landscape', diptych.config.orientation !== 'portrait');
         try {
             // Include crop_focus in payload
             const diptychPayload = JSON.parse(JSON.stringify(diptych));


### PR DESCRIPTION
## Summary
- update tray preview sizing based on orientation
- refresh previews when orientation changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccef000808322947a2b558f2833ff