### PR TITLE
Add low-res preview thumbnails

### DIFF
--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -188,6 +188,24 @@
     transition: opacity 0.3s ease-in-out;
 }
 
+#lowres-preview {
+    position: absolute;
+    inset: 0;
+    display: none;
+    z-index: 1;
+}
+#lowres-preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+#lowres-preview.landscape {
+    flex-direction: row;
+}
+#lowres-preview.portrait {
+    flex-direction: column;
+}
+
 #preview-image:not(.hidden) {
     opacity: 1;
 }

--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -469,16 +469,48 @@ const DiptychApp = (() => {
         appState.previewDebounceTimer = setTimeout(refreshWysiwygPreview, PREVIEW_DEBOUNCE_DELAY);
     }
 
+    function showLowResPreview(diptych) {
+        const container = document.getElementById('lowres-preview');
+        const img1 = document.getElementById('lowres-img1');
+        const img2 = document.getElementById('lowres-img2');
+        if (!diptych) return;
+        container.classList.remove('hidden');
+        container.classList.toggle('portrait', diptych.config.orientation === 'portrait');
+        container.classList.toggle('landscape', diptych.config.orientation !== 'portrait');
+        container.style.backgroundColor = diptych.config.border_color;
+        if (diptych.image1) {
+            img1.src = `/thumbnail/${encodeURIComponent(diptych.image1.path)}`;
+            img1.classList.remove('hidden');
+        } else {
+            img1.classList.add('hidden');
+            img1.removeAttribute('src');
+        }
+        if (diptych.image2) {
+            img2.src = `/thumbnail/${encodeURIComponent(diptych.image2.path)}`;
+            img2.classList.remove('hidden');
+        } else {
+            img2.classList.add('hidden');
+            img2.removeAttribute('src');
+        }
+    }
+
+    function hideLowResPreview() {
+        const container = document.getElementById('lowres-preview');
+        container.classList.add('hidden');
+    }
+
     async function refreshWysiwygPreview() {
         const activeDiptych = appState.diptychs[appState.activeDiptychIndex];
         if (!activeDiptych || (!activeDiptych.image1 && !activeDiptych.image2)) {
             previewImage.classList.add('hidden');
             mainCanvas.classList.remove('preview-loading');
+            hideLowResPreview();
             return;
         }
         // Ensure preview background matches outer border color
         previewImage.style.backgroundColor = activeDiptych.config.border_color;
         mainCanvas.style.backgroundColor = activeDiptych.config.border_color;
+        showLowResPreview(activeDiptych);
         try {
             mainCanvas.classList.add('preview-loading');
             // Create a deep copy of the diptych and attach crop_focus to each image
@@ -498,6 +530,7 @@ const DiptychApp = (() => {
             previewImage.onload = () => {
                 previewImage.classList.remove('hidden');
                 mainCanvas.classList.remove('preview-loading');
+                hideLowResPreview();
                 URL.revokeObjectURL(imageUrl);
             };
             previewImage.src = imageUrl;
@@ -505,6 +538,7 @@ const DiptychApp = (() => {
             console.error('Preview generation failed:', error);
             previewImage.classList.add('hidden');
             mainCanvas.classList.remove('preview-loading');
+            hideLowResPreview();
         }
     }
 

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -66,6 +66,10 @@
             <div class="flex-1 flex flex-col items-center justify-center p-4 sm:p-6 md:p-8 bg-gray-50 relative">
                 <div id="main-canvas" class="w-full max-w-2xl shadow-2xl border border-[var(--border-color)] overflow-hidden relative">
                     <img id="preview-image" class="absolute inset-0 w-full h-full object-cover hidden" alt="Diptych Preview">
+                    <div id="lowres-preview" class="absolute inset-0 flex hidden" aria-hidden="true">
+                        <img id="lowres-img1" class="flex-1 object-cover" alt="Low res image 1">
+                        <img id="lowres-img2" class="flex-1 object-cover" alt="Low res image 2">
+                    </div>
                     <div id="canvas-grid" class="absolute inset-0 grid grid-cols-2 h-full">
                         <div class="drop-zone" data-slot="1"></div>
                         <div class="drop-zone" data-slot="2"></div>


### PR DESCRIPTION
## Summary
- display a new low-resolution preview using the uploaded thumbnails
- style the preview container for portrait and landscape
- generate the low-res preview while the high-res preview loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cced8be5883228de462fe94f691a7