### PR TITLE
Persist diptych order in server

### DIFF
--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -453,6 +453,21 @@ const DiptychApp = (() => {
         addButton.className = 'add-diptych-btn';
         addButton.innerHTML = `<svg fill="currentColor" height="24" viewBox="0 0 256 256" width="24"><path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path></svg>`;
         diptychTray.appendChild(addButton);
+        sendDiptychOrder();
+    }
+
+    async function sendDiptychOrder() {
+        const order = Array.from(diptychTray.querySelectorAll('.diptych-tray-item'))
+            .map(el => parseInt(el.dataset.index, 10));
+        try {
+            await fetch('/set_diptych_order', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ order })
+            });
+        } catch (err) {
+            console.error('Failed to persist diptych order', err);
+        }
     }
 
     function updateActiveTrayPreview() {
@@ -612,7 +627,10 @@ const DiptychApp = (() => {
                 const img2 = d.image2 ? { ...d.image2, crop_focus: d.config.crop_focus } : null;
                 return { pair: [img1, img2], config: d.config };
             }),
-            zip: zipToggle.checked
+            zip: zipToggle.checked,
+            order: appState.diptychs
+                .map((d, idx) => d.image1 && d.image2 ? idx : null)
+                .filter(idx => idx !== null)
         };
         try {
             const startResponse = await fetch('/generate_diptychs', {

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,0 +1,53 @@
+import os
+import time
+from PIL import Image
+from app import app, UPLOAD_DIR, progress_data, progress_lock
+
+
+def create_image(name, color):
+    path = os.path.join(UPLOAD_DIR, name)
+    Image.new('RGB', (10, 10), color).save(path)
+    return name
+
+
+def wait_generation(client):
+    for _ in range(100):
+        resp = client.get('/get_generation_progress')
+        data = resp.get_json()
+        if data['processed'] >= data['total']:
+            break
+        time.sleep(0.05)
+    return data
+
+
+def test_generate_diptychs_order(tmp_path):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    create_image('a.jpg', 'red')
+    create_image('b.jpg', 'green')
+    create_image('c.jpg', 'blue')
+    create_image('d.jpg', 'yellow')
+    with progress_lock:
+        progress_data.clear()
+    with app.test_client() as client:
+        payload = {
+            'pairs': [
+                {'pair': [{'path': 'a.jpg'}, {'path': 'b.jpg'}],
+                 'config': {'width': 1, 'height': 1, 'dpi': 10}},
+                {'pair': [{'path': 'c.jpg'}, {'path': 'd.jpg'}],
+                 'config': {'width': 1, 'height': 1, 'dpi': 10}},
+            ],
+            'order': [1, 0],
+            'zip': False
+        }
+        resp = client.post('/generate_diptychs', json=payload)
+        assert resp.status_code == 200
+        progress = wait_generation(client)
+        assert progress['processed'] == progress['total'] == 2
+        first = progress['final_paths'][0]
+        img = Image.open(first)
+        # First pixel should come from c.jpg (blue)
+        color = img.getpixel((0, 0))
+        assert color[2] > 200 and color[0] < 50 and color[1] < 50
+        from app import diptych_order, diptych_order_lock
+        with diptych_order_lock:
+            assert diptych_order == [1, 0]


### PR DESCRIPTION
## Summary
- keep diptych order server-side
- add `/set_diptych_order` endpoint
- include order in `/generate_diptychs`
- persist order from the client
- test order persistence and generation sequence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccec0db5c83229b059eb6f424d974