### PR TITLE
Add EXIF metadata preservation option

### DIFF
--- a/app.py
+++ b/app.py
@@ -365,6 +365,7 @@ def generate_diptychs():
                     border_color,
                     crop_focus1,
                     crop_focus2,
+                    bool(config.get('preserve_exif')),
                 )
                 with progress_lock:
                     progress_data["processed"] += 1


### PR DESCRIPTION
## Summary
- allow `create_diptych` to optionally embed EXIF data from the first image
- expose new option through the Flask app
- test EXIF metadata preservation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccefc8f308322b7eb71ff1fd1d433