### PR TITLE
Improve mobile layout with tabbed panels

### DIFF
--- a/review_app/static/css/style.css
+++ b/review_app/static/css/style.css
@@ -342,10 +342,20 @@
 
 /* --- Mobile Responsiveness --- */
 @media (max-width: 768px) {
+    #bottom-bar {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 30;
+    }
+    main {
+        padding-bottom: 5rem;
+    }
     #left-panel, #right-panel {
         position: fixed;
-        top: 60px;
-        bottom: 0;
+        top: 100px;
+        bottom: 5rem;
         z-index: 40;
         background: white;
         overflow-y: auto;
@@ -363,4 +373,16 @@
     #right-panel:not(.hidden) {
         transform: translateX(0);
     }
+    #mobile-tabs button.mobile-tab-active {
+        border-color: var(--primary-color);
+        color: var(--primary-color);
+    }
+}
+
+details > summary {
+    cursor: pointer;
+    list-style: none;
+}
+details > summary::-webkit-details-marker {
+    display: none;
 }

--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -55,6 +55,8 @@ const DiptychApp = (() => {
     const outerBorderSizeSlider = document.getElementById('outer-border-size');
     const outerBorderSizeValue = document.getElementById('outer-border-size-value');
     const borderColorInput = document.getElementById('border-color');
+    const tabImagesBtn = document.getElementById('tab-images');
+    const tabSettingsBtn = document.getElementById('tab-settings');
     // Crop focus selectors (horizontal and vertical) allow the user to
     // choose which part of the image is preserved when cropping.  Values
     // correspond to 0 (start), 0.5 (center) and 1 (end).
@@ -95,6 +97,10 @@ const DiptychApp = (() => {
         diptychTray.addEventListener('click', handleTrayClick);
         document.getElementById('scroll-left-btn').addEventListener('click', () => scrollTray(-200));
         document.getElementById('scroll-right-btn').addEventListener('click', () => scrollTray(200));
+        if (tabImagesBtn && tabSettingsBtn) {
+            tabImagesBtn.addEventListener('click', () => toggleMobileTab('images'));
+            tabSettingsBtn.addEventListener('click', () => toggleMobileTab('settings'));
+        }
     }
 
     // --- UI & STATE ---
@@ -132,6 +138,23 @@ const DiptychApp = (() => {
         } else {
             leftPanel.classList.add('hidden');
             rightPanel.classList.add('hidden');
+        }
+        updateMobileMenuIcon();
+    }
+
+    function toggleMobileTab(which) {
+        if (which === 'images') {
+            const currentlyVisible = !leftPanel.classList.contains('hidden');
+            leftPanel.classList.toggle('hidden', currentlyVisible);
+            rightPanel.classList.add('hidden');
+            tabImagesBtn.classList.toggle('mobile-tab-active', !currentlyVisible);
+            tabSettingsBtn.classList.remove('mobile-tab-active');
+        } else if (which === 'settings') {
+            const currentlyVisible = !rightPanel.classList.contains('hidden');
+            rightPanel.classList.toggle('hidden', currentlyVisible);
+            leftPanel.classList.add('hidden');
+            tabSettingsBtn.classList.toggle('mobile-tab-active', !currentlyVisible);
+            tabImagesBtn.classList.remove('mobile-tab-active');
         }
         updateMobileMenuIcon();
     }

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -50,6 +50,12 @@
             </div>
         </header>
 
+        <!-- Mobile tab bar shown under the header -->
+        <div id="mobile-tabs" class="md:hidden flex border-b border-[var(--accent-color)]">
+            <button id="tab-images" class="flex-1 py-2 text-sm font-medium text-center border-b-2 border-transparent">Images</button>
+            <button id="tab-settings" class="flex-1 py-2 text-sm font-medium text-center border-b-2 border-transparent">Settings</button>
+        </div>
+
         <main class="flex flex-1 flex-col md:flex-row overflow-y-auto">
             <aside id="left-panel" class="w-full md:w-72 border-b md:border-b-0 md:border-r border-[var(--accent-color)] p-4 space-y-4 hidden md:flex flex-col">
                 <div>
@@ -121,36 +127,39 @@
                             </div>
                             <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="border-size" max="100" min="0" name="border-size" type="range" value="20"/>
                         </div>
-                        <div>
-                            <div class="flex items-center justify-between">
-                                <label class="config-label" for="outer-border-size">Outer Border Size</label>
-                                <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">0 mm</p>
+                        <details id="advanced-options" class="space-y-3">
+                            <summary class="config-heading cursor-pointer select-none">More Options</summary>
+                            <div>
+                                <div class="flex items-center justify-between">
+                                    <label class="config-label" for="outer-border-size">Outer Border Size</label>
+                                    <p id="outer-border-size-value" class="text-xs text-[var(--text-secondary)]">0 mm</p>
+                                </div>
+                                <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="outer-border-size" max="100" min="0" name="outer-border-size" type="range" value="20"/>
                             </div>
-                            <input class="w-full h-2 bg-[var(--border-color)] rounded-lg appearance-none cursor-pointer accent-[var(--primary-color)] mt-1" id="outer-border-size" max="100" min="0" name="outer-border-size" type="range" value="20"/>
-                        </div>
-                        <div>
-                            <label class="config-label" for="border-color">Border Color</label>
-                            <input type="color" id="border-color" name="border-color" value="#ffffff" class="form-input-custom" style="width: 3rem; height: 2rem; padding: 0; border-radius: 0.5rem;">
-                        </div>
-                        <!-- Crop focus controls allow users to choose which part of the image
-                             is preserved when cropping.  Horizontal (left, center, right) and
-                             vertical (top, center, bottom) positions map to 0.0, 0.5 and 1.0
-                             respectively. -->
-                        <div>
-                            <label class="config-label" for="crop-focus-h">Crop Focus</label>
-                            <div class="flex gap-2 mt-1">
-                                <select id="crop-focus-h" name="crop-focus-h" aria-label="Horizontal crop focus" class="form-input-custom flex-1">
-                                    <option value="0">Left</option>
-                                    <option value="0.5" selected>Center</option>
-                                    <option value="1">Right</option>
-                                </select>
-                                <select id="crop-focus-v" name="crop-focus-v" aria-label="Vertical crop focus" class="form-input-custom flex-1">
-                                    <option value="0">Top</option>
-                                    <option value="0.5" selected>Center</option>
-                                    <option value="1">Bottom</option>
-                                </select>
+                            <div>
+                                <label class="config-label" for="border-color">Border Color</label>
+                                <input type="color" id="border-color" name="border-color" value="#ffffff" class="form-input-custom" style="width: 3rem; height: 2rem; padding: 0; border-radius: 0.5rem;">
                             </div>
-                        </div>
+                            <!-- Crop focus controls allow users to choose which part of the image
+                                 is preserved when cropping.  Horizontal (left, center, right) and
+                                 vertical (top, center, bottom) positions map to 0.0, 0.5 and 1.0
+                                 respectively. -->
+                            <div>
+                                <label class="config-label" for="crop-focus-h">Crop Focus</label>
+                                <div class="flex gap-2 mt-1">
+                                    <select id="crop-focus-h" name="crop-focus-h" aria-label="Horizontal crop focus" class="form-input-custom flex-1">
+                                        <option value="0">Left</option>
+                                        <option value="0.5" selected>Center</option>
+                                        <option value="1">Right</option>
+                                    </select>
+                                    <select id="crop-focus-v" name="crop-focus-v" aria-label="Vertical crop focus" class="form-input-custom flex-1">
+                                        <option value="0">Top</option>
+                                        <option value="0.5" selected>Center</option>
+                                        <option value="1">Bottom</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </details>
                     </div>
                 </div>
                 <div id="image-1-controls" class="hidden">


### PR DESCRIPTION
## Summary
- add mobile tab bar for switching between panels
- collapse advanced settings into `<details>`
- adjust CSS for fixed bottom bar and tab styles
- add JS handlers for tab switching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cced3d8bc8322b0f267b04f4a667a