### PR TITLE
Add undo/redo support

### DIFF
--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -45,6 +45,8 @@
                     <option value="orientation">By Orientation</option>
                 </select>
                 <button id="auto-pair-btn" aria-label="Automatically pair images" class="btn btn-secondary"><span class="truncate">Auto Pair</span></button>
+                <button id="undo-btn" class="icon-btn" aria-label="Undo"><svg fill="currentColor" height="18" viewBox="0 0 256 256" width="18"><path d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z"></path></svg></button>
+                <button id="redo-btn" class="icon-btn" aria-label="Redo"><svg fill="currentColor" height="18" viewBox="0 0 256 256" width="18"><path d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"></path></svg></button>
                 <button id="download-btn" aria-label="Download all diptychs" class="btn btn-primary"><span class="truncate">Download All</span></button>
                 <button id="mobile-menu-btn" class="icon-btn md:hidden"></button>
             </div>


### PR DESCRIPTION
## Summary
- add undo/redo buttons to the main interface
- implement history stack in frontend
- push state changes for uploads, layout edits and reordering
- expose undo/redo controls in the header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccec65cac83229d9d1d6f0eb7b41f