### PR TITLE
Add new image grouping modes

### DIFF
--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -220,7 +220,9 @@ const DiptychApp = (() => {
             const baseConfig = appState.diptychs.length > 0
                 ? { ...appState.diptychs[appState.activeDiptychIndex].config }
                 : { fit_mode: 'fit', gap: 20, width: 6, height: 4, orientation: 'landscape', dpi: 300, outer_border: 20, border_color: '#ffffff' };
-            // Determine grouping method from the selector.  Defaults to chronological.
+            // Determine grouping method from the selector.  Supported options
+            // mirror the server: chronological, orientation, aspect_ratio,
+            // dominant_color and random. Defaults to chronological.
             const method = groupingMethodSelect ? groupingMethodSelect.value : 'chronological';
             const response = await fetch('/auto_group', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ method }) });
             if (!response.ok) throw new Error('Auto grouping failed');

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -43,6 +43,9 @@
                 <select id="grouping-method" aria-label="Auto pair grouping method" class="form-select mr-2" style="padding: 0.5rem 0.75rem; border-radius: 0.375rem; border: 1px solid var(--border-color); background-color: white; color: var(--text-primary);">
                     <option value="chronological">Chronological</option>
                     <option value="orientation">By Orientation</option>
+                    <option value="aspect_ratio">Aspect Ratio</option>
+                    <option value="dominant_color">Dominant Color</option>
+                    <option value="random">Random</option>
                 </select>
                 <button id="auto-pair-btn" aria-label="Automatically pair images" class="btn btn-secondary"><span class="truncate">Auto Pair</span></button>
                 <button id="download-btn" aria-label="Download all diptychs" class="btn btn-primary"><span class="truncate">Download All</span></button>


### PR DESCRIPTION
## Summary
- add aspect ratio, dominant colour and random grouping algorithms
- expose new grouping options in the UI
- document options in JS comment
- test new grouping methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccebad1ac8322a28080f5096526e8