### PR TITLE
Enable custom dimension inputs for custom aspect ratios

### DIFF
--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -82,7 +82,7 @@ const DiptychApp = (() => {
         downloadBtn.addEventListener('click', generateDiptychs);
         autoPairBtn.addEventListener('click', autoPairImages);
         mobileMenuBtn.addEventListener('click', toggleMobilePanels);
-        outputSizeSelect.addEventListener('change', handleConfigChange);
+        outputSizeSelect.addEventListener('change', handleOutputSizeChange);
         orientationBtn.addEventListener('click', toggleOrientation);
         [customWidthInput, customHeightInput].forEach(el => el.addEventListener('input', handleConfigChange));
         outputDpiSelect.addEventListener('change', handleConfigChange);
@@ -267,17 +267,26 @@ const DiptychApp = (() => {
         }
     }
 
+    function handleOutputSizeChange() {
+        const selected = outputSizeSelect.value;
+        const isCustom = selected === 'custom';
+        customDimContainer.classList.toggle('hidden', !isCustom);
+        if (isCustom) {
+            const activeDiptych = appState.diptychs[appState.activeDiptychIndex];
+            if (activeDiptych) {
+                customWidthInput.value = activeDiptych.config.width;
+                customHeightInput.value = activeDiptych.config.height;
+            }
+            customWidthInput.focus();
+        }
+        handleConfigChange();
+    }
+
     function handleConfigChange() {
         const activeDiptych = appState.diptychs[appState.activeDiptychIndex];
         if (!activeDiptych) return;
         const config = activeDiptych.config;
         const selectedSize = outputSizeSelect.value;
-        const isSwitchingToCustom = selectedSize === 'custom' && customDimContainer.classList.contains('hidden');
-        if (isSwitchingToCustom) {
-            customWidthInput.value = config.width;
-            customHeightInput.value = config.height;
-        }
-        customDimContainer.classList.toggle('hidden', selectedSize !== 'custom');
         if (selectedSize === 'custom') {
             config.width = parseFloat(customWidthInput.value) || 10;
             config.height = parseFloat(customHeightInput.value) || 8;


### PR DESCRIPTION
## Summary
- Show width and height inputs when "Custom" output size is selected
- Keep diptych configuration in sync with user-provided custom dimensions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec66939088322990fbe076a61ce00