### PR TITLE
Fix square aspect ratio orientation

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,7 @@ def _generate_preview_job(job_id: str, diptych_data: dict) -> None:
             processing_dims = (inner_w - effective_gap, inner_h)
 
         img1 = img2 = None
+        is_landscape = config.get('orientation') != 'portrait'
         if image1_data:
             path1 = os.path.join(UPLOAD_DIR, secure_filename(os.path.basename(image1_data['path'])))
             if not os.path.exists(path1):
@@ -155,6 +156,7 @@ def _generate_preview_job(job_id: str, diptych_data: dict) -> None:
                 True,
                 border_color,
                 crop_focus1,
+                is_landscape,
             )
         if image2_data:
             path2 = os.path.join(UPLOAD_DIR, secure_filename(os.path.basename(image2_data['path'])))
@@ -169,6 +171,7 @@ def _generate_preview_job(job_id: str, diptych_data: dict) -> None:
                 True,
                 border_color,
                 crop_focus2,
+                is_landscape,
             )
         if not img1 and not img2:
             raise RuntimeError('Error processing images')
@@ -365,6 +368,7 @@ def get_wysiwyg_preview():
         # provided by the client to control which part of the image is kept
         # during cropping.  If absent, center cropping is used.
         img1, img2 = None, None
+        is_landscape = config.get('orientation') != 'portrait'
         if image1_data:
             path1 = os.path.join(UPLOAD_DIR, secure_filename(os.path.basename(image1_data['path'])))
             if not os.path.exists(path1):
@@ -378,6 +382,7 @@ def get_wysiwyg_preview():
                 True,
                 config.get('border_color', 'white'),
                 crop_focus1,
+                is_landscape,
             )
         if image2_data:
             path2 = os.path.join(UPLOAD_DIR, secure_filename(os.path.basename(image2_data['path'])))
@@ -392,6 +397,7 @@ def get_wysiwyg_preview():
                 True,
                 config.get('border_color', 'white'),
                 crop_focus2,
+                is_landscape,
             )
         if not img1 and not img2:
             return "Error processing images", 500

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -15,7 +15,7 @@ from datetime import datetime
 
 def cell_size(final_dims, gap, outer=0, both=True):
     w, h = final_dims
-    landscape = w > h
+    landscape = w >= h
     inner_w = w - 2 * outer
     inner_h = h - 2 * outer
     effective_gap = gap if both else 0
@@ -52,6 +52,17 @@ def test_portrait_no_gap_when_missing_image():
     img = make_img(cell_w, cell_h)
     canvas = create_diptych_canvas(None, img, (50, 100), gap_px=10)
     assert canvas.size == (50, 100)
+
+
+def test_square_treated_as_landscape():
+    cell_w, cell_h = cell_size((100, 100), 10, both=True)
+    img1 = make_img(cell_w, cell_h, 'red')
+    img2 = make_img(cell_w, cell_h, 'blue')
+    canvas = create_diptych_canvas(img1, img2, (100, 100), gap_px=10)
+    # left sample should be red
+    assert canvas.getpixel((cell_w // 2, cell_h // 2)) == (255, 0, 0)
+    # right sample should be blue
+    assert canvas.getpixel((100 - cell_w // 2 - 1, cell_h // 2)) == (0, 0, 255)
 
 
 def test_auto_rotate_landscape_into_portrait_cell(tmp_path):


### PR DESCRIPTION
## Summary
- preserve landscape layout for square diptychs by overriding orientation detection
- ensure canvas assembly uses landscape logic when width equals height
- cover square diptych behavior with regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec68608b88322b9c075f9de13925e