### PR TITLE
Persist diptych order

### DIFF
--- a/review_app/static/js/app.js
+++ b/review_app/static/js/app.js
@@ -215,6 +215,7 @@ const DiptychApp = (() => {
         if (andSwitch) appState.activeDiptychIndex = appState.diptychs.length - 1;
         renderDiptychTray();
         if (andSwitch) renderActiveDiptychUI();
+        persistDiptychOrder();
     }
 
     function switchActiveDiptych(index) {
@@ -235,6 +236,7 @@ const DiptychApp = (() => {
             renderDiptychTray();
             renderImagePool();
             renderActiveDiptychUI();
+            persistDiptychOrder();
         }
     }
 
@@ -260,6 +262,7 @@ const DiptychApp = (() => {
             renderDiptychTray();
             renderImagePool();
             renderActiveDiptychUI();
+            persistDiptychOrder();
         } catch (err) {
             alert('Auto pairing failed: ' + err.message);
         } finally {
@@ -513,6 +516,7 @@ const DiptychApp = (() => {
                     appState.diptychs = newDiptychs;
                     if (newActive !== -1) appState.activeDiptychIndex = newActive;
                     renderDiptychTray();
+                    persistDiptychOrder();
                 }
             });
         }
@@ -523,6 +527,22 @@ const DiptychApp = (() => {
         if (item) {
             const preview = item.querySelector('.diptych-tray-preview');
             if (preview) updateTrayPreview(preview, appState.diptychs[appState.activeDiptychIndex]);
+        }
+    }
+
+    async function persistDiptychOrder() {
+        try {
+            const order = appState.diptychs.map(d => ({
+                image1: d.image1 ? d.image1.path : null,
+                image2: d.image2 ? d.image2.path : null,
+            }));
+            await fetch('/update_diptych_order', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ order })
+            });
+        } catch (err) {
+            console.error('Failed to persist diptych order:', err);
         }
     }
 
@@ -714,6 +734,10 @@ const DiptychApp = (() => {
                 const img2 = d.image2 ? { ...d.image2, crop_focus: d.config.crop_focus } : null;
                 return { pair: [img1, img2], config: d.config };
             }),
+            order: appState.diptychs.map(d => ({
+                image1: d.image1 ? d.image1.path : null,
+                image2: d.image2 ? d.image2.path : null,
+            })),
             zip: zipToggle.checked
         };
         try {

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,0 +1,43 @@
+import os
+import time
+from PIL import Image
+
+from app import app, UPLOAD_DIR
+
+
+def create_image(path, color):
+    Image.new('RGB', (20, 20), color).save(path)
+
+
+def test_generate_respects_order(tmp_path):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    img_paths = []
+    colors = ['red', 'green', 'blue', 'yellow']
+    names = ['a.jpg', 'b.jpg', 'c.jpg', 'd.jpg']
+    for name, color in zip(names, colors):
+        p = os.path.join(UPLOAD_DIR, name)
+        create_image(p, color)
+        img_paths.append(p)
+    pair1 = {'pair': [{'path': img_paths[0]}, {'path': img_paths[1]}], 'config': {'width': 4, 'height': 3, 'dpi': 10}}
+    pair2 = {'pair': [{'path': img_paths[2]}, {'path': img_paths[3]}], 'config': {'width': 4, 'height': 3, 'dpi': 10}}
+    order = [
+        {'image1': img_paths[2], 'image2': img_paths[3]},
+        {'image1': img_paths[0], 'image2': img_paths[1]},
+    ]
+    with app.test_client() as client:
+        resp = client.post('/generate_diptychs', json={'pairs': [pair1, pair2], 'order': order, 'zip': False})
+        assert resp.status_code == 200
+        # wait for background task to finish
+        while True:
+            progress = client.get('/get_generation_progress').get_json()
+            if progress['processed'] >= progress['total']:
+                break
+            time.sleep(0.1)
+        final = client.get('/finalize_download').get_json()
+        assert final['is_zip'] is False
+        paths_out = final['download_paths']
+        assert len(paths_out) == 2
+        first = Image.open(paths_out[0])
+        r, g, b = first.getpixel((0, first.height // 2))
+        # first image should start with blue from pair2
+        assert b > r and b > g


### PR DESCRIPTION
## Summary
- persist current diptych order on the server via `/update_diptych_order`
- send diptych order with generation request so final downloads match UI
- test that generation obeys the provided order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec63d18c483228a22f58a29f171fa