### PR TITLE
Handle mirrored EXIF orientations

### DIFF
--- a/diptych_creator.py
+++ b/diptych_creator.py
@@ -59,10 +59,10 @@ def apply_exif_orientation(img):
     2 - Mirror horizontal
     3 - Rotate 180
     4 - Mirror vertical
-    5 - Mirror horizontal and rotate 270 CW
-    6 - Rotate 270 CW
-    7 - Mirror horizontal and rotate 90 CW
-    8 - Rotate 90 CW
+    5 - Mirror horizontal and rotate 90° counter-clockwise
+    6 - Rotate 90° clockwise
+    7 - Mirror horizontal and rotate 90° clockwise
+    8 - Rotate 90° counter-clockwise
 
     If the orientation tag is missing or an unexpected value is encountered,
     the image is returned unchanged.
@@ -84,18 +84,18 @@ def apply_exif_orientation(img):
                 # Mirror vertically
                 img = img.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
             elif orientation == 5:
-                # Mirror horizontally and rotate 270° CW (–90°)
+                # Mirror horizontally and rotate 90° CCW
                 img = img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
-                img = img.rotate(-90, expand=True)
+                img = img.rotate(90, expand=True)
             elif orientation == 6:
-                # Rotate 270° CW (–90°)
+                # Rotate 90° CW
                 img = img.rotate(-90, expand=True)
             elif orientation == 7:
                 # Mirror horizontally and rotate 90° CW
                 img = img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
-                img = img.rotate(90, expand=True)
+                img = img.rotate(-90, expand=True)
             elif orientation == 8:
-                # Rotate 90° CW
+                # Rotate 90° CCW
                 img = img.rotate(90, expand=True)
     except Exception:
         # If anything goes wrong while reading EXIF, return original

--- a/tests/test_exif_orientation.py
+++ b/tests/test_exif_orientation.py
@@ -1,0 +1,54 @@
+import pytest
+from PIL import Image
+
+from diptych_creator import apply_exif_orientation, ORIENTATION_TAG
+
+
+def build_image(size, pixels):
+    img = Image.new('RGB', size)
+    for (x, y), color in pixels.items():
+        img.putpixel((x, y), color)
+    return img
+
+
+def attach_orientation(img, orientation):
+    def _getexif():
+        return {ORIENTATION_TAG: orientation}
+    img._getexif = _getexif
+    return img
+
+
+def test_orientation_2_horizontal_flip():
+    img = build_image((2, 1), {(0, 0): (255, 0, 0), (1, 0): (0, 0, 255)})
+    img = attach_orientation(img, 2)
+    result = apply_exif_orientation(img)
+    assert result.size == (2, 1)
+    assert result.getpixel((0, 0)) == (0, 0, 255)
+    assert result.getpixel((1, 0)) == (255, 0, 0)
+
+
+def test_orientation_4_vertical_flip():
+    img = build_image((1, 2), {(0, 0): (255, 0, 0), (0, 1): (0, 0, 255)})
+    img = attach_orientation(img, 4)
+    result = apply_exif_orientation(img)
+    assert result.size == (1, 2)
+    assert result.getpixel((0, 0)) == (0, 0, 255)
+    assert result.getpixel((0, 1)) == (255, 0, 0)
+
+
+def test_orientation_5_mirror_and_rotate():
+    img = build_image((2, 1), {(0, 0): (255, 0, 0), (1, 0): (0, 0, 255)})
+    img = attach_orientation(img, 5)
+    result = apply_exif_orientation(img)
+    assert result.size == (1, 2)
+    assert result.getpixel((0, 0)) == (255, 0, 0)
+    assert result.getpixel((0, 1)) == (0, 0, 255)
+
+
+def test_orientation_7_mirror_and_rotate():
+    img = build_image((2, 1), {(0, 0): (255, 0, 0), (1, 0): (0, 0, 255)})
+    img = attach_orientation(img, 7)
+    result = apply_exif_orientation(img)
+    assert result.size == (1, 2)
+    assert result.getpixel((0, 0)) == (0, 0, 255)
+    assert result.getpixel((0, 1)) == (255, 0, 0)


### PR DESCRIPTION
## Summary
- correct mirrored EXIF orientation handling for values 2,4,5,7
- document full orientation mapping in `apply_exif_orientation`
- add unit tests covering mirrored orientations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec646fd90832295ab78d7bab2e673