### PR TITLE
feat: add more image grouping options

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,8 @@ from werkzeug.utils import secure_filename
 from concurrent.futures import ThreadPoolExecutor
 from PIL import Image, ExifTags
 import uuid
+import random
+import colorsys
 
 # Configure Flask to look in the `review_app` folder for templates and static assets.
 app = Flask(__name__, template_folder='review_app/templates', static_folder='review_app/static')
@@ -255,6 +257,11 @@ def auto_group():
       Landscape images will be paired with other landscape images first, then
       portrait images will be paired together.  If there is an odd number in
       either group, the leftover image will form a single-image diptych.
+    - ``aspect_ratio``: sort by each image's width/height ratio and pair similar
+      ratios together.
+    - ``dominant_color``: approximate the dominant colour of each image and
+      pair by similar hues.
+    - ``random``: shuffle images randomly before pairing.
     """
     data = request.get_json(silent=True) or {}
     method = (data.get('method') or 'chronological').lower()
@@ -263,13 +270,24 @@ def auto_group():
     info: list[dict] = []
     for f in files:
         path = os.path.join(UPLOAD_DIR, f)
-        # Determine orientation: landscape (True) or portrait (False)
         try:
             with Image.open(path) as img:
                 landscape = img.width >= img.height
+                ratio = img.width / img.height if img.height else 1.0
+                # Downscale to 1x1 to approximate dominant colour quickly
+                r, g, b = img.resize((1, 1)).convert('RGB').getpixel((0, 0))
+                hue = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)[0]
         except Exception:
             landscape = True
-        info.append({'name': f, 'time': get_capture_time(path), 'landscape': landscape})
+            ratio = 1.0
+            hue = 0.0
+        info.append({
+            'name': f,
+            'time': get_capture_time(path),
+            'landscape': landscape,
+            'ratio': ratio,
+            'hue': hue,
+        })
     pairs: list[list[str]] = []
     if method == 'orientation':
         # Split into landscape and portrait lists
@@ -289,6 +307,27 @@ def auto_group():
             return res
         pairs.extend(pair_items(landscapes))
         pairs.extend(pair_items(portraits))
+    elif method == 'aspect_ratio':
+        info.sort(key=lambda x: x['ratio'])
+        for i in range(0, len(info), 2):
+            pair = [info[i]['name']]
+            if i + 1 < len(info):
+                pair.append(info[i + 1]['name'])
+            pairs.append(pair)
+    elif method == 'dominant_color':
+        info.sort(key=lambda x: x['hue'])
+        for i in range(0, len(info), 2):
+            pair = [info[i]['name']]
+            if i + 1 < len(info):
+                pair.append(info[i + 1]['name'])
+            pairs.append(pair)
+    elif method == 'random':
+        random.shuffle(info)
+        for i in range(0, len(info), 2):
+            pair = [info[i]['name']]
+            if i + 1 < len(info):
+                pair.append(info[i + 1]['name'])
+            pairs.append(pair)
     else:
         # Chronological by default
         info.sort(key=lambda x: x['time'])

--- a/review_app/templates/index.html
+++ b/review_app/templates/index.html
@@ -43,6 +43,9 @@
                 <select id="grouping-method" aria-label="Auto pair grouping method" class="form-select mr-2" style="padding: 0.5rem 0.75rem; border-radius: 0.375rem; border: 1px solid var(--border-color); background-color: white; color: var(--text-primary);">
                     <option value="chronological">Chronological</option>
                     <option value="orientation">By Orientation</option>
+                    <option value="aspect_ratio">By Aspect Ratio</option>
+                    <option value="dominant_color">By Dominant Colour</option>
+                    <option value="random">Random</option>
                 </select>
                 <button id="auto-pair-btn" aria-label="Automatically pair images" class="btn btn-secondary"><span class="truncate">Auto Pair</span></button>
                 <button id="download-btn" aria-label="Download all diptychs" class="btn btn-primary"><span class="truncate">Download All</span></button>

--- a/tests/test_diptych_creator.py
+++ b/tests/test_diptych_creator.py
@@ -12,6 +12,8 @@ if PROJECT_ROOT not in sys.path:
 from diptych_creator import create_diptych_canvas, process_source_image, create_diptych
 from app import app, get_capture_time, UPLOAD_TIMES, UPLOAD_DIR
 from datetime import datetime
+import random
+from unittest.mock import patch
 
 def cell_size(final_dims, gap, outer=0, both=True):
     w, h = final_dims
@@ -26,6 +28,14 @@ def cell_size(final_dims, gap, outer=0, both=True):
 
 def make_img(w=50, h=50, color='white'):
     return Image.new('RGB', (w, h), color)
+
+
+def clear_upload_dir():
+    if os.path.exists(UPLOAD_DIR):
+        for f in os.listdir(UPLOAD_DIR):
+            path = os.path.join(UPLOAD_DIR, f)
+            if os.path.isfile(path):
+                os.remove(path)
 
 def test_landscape_gap_used_when_both_images():
     cell_w, cell_h = cell_size((100, 50), 10, both=True)
@@ -94,6 +104,7 @@ def test_fit_mode_background_color(tmp_path):
 
 
 def test_auto_group_chronological(tmp_path):
+    clear_upload_dir()
     os.makedirs(UPLOAD_DIR, exist_ok=True)
     img1 = os.path.join(UPLOAD_DIR, 'old.jpg')
     img2 = os.path.join(UPLOAD_DIR, 'mid.jpg')
@@ -114,6 +125,63 @@ def test_auto_group_chronological(tmp_path):
         pairs = resp.get_json()['pairs']
 
     assert pairs[0] == ['old.jpg', 'mid.jpg']
+    clear_upload_dir()
+
+
+def test_auto_group_aspect_ratio(tmp_path):
+    clear_upload_dir()
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    img1 = os.path.join(UPLOAD_DIR, 'square1.jpg')
+    img2 = os.path.join(UPLOAD_DIR, 'square2.jpg')
+    img3 = os.path.join(UPLOAD_DIR, 'wide1.jpg')
+    img4 = os.path.join(UPLOAD_DIR, 'wide2.jpg')
+    Image.new('RGB', (100, 100), 'red').save(img1)
+    Image.new('RGB', (110, 100), 'red').save(img2)
+    Image.new('RGB', (200, 100), 'red').save(img3)
+    Image.new('RGB', (210, 100), 'red').save(img4)
+    with app.test_client() as client:
+        resp = client.post('/auto_group', json={'method': 'aspect_ratio'})
+        assert resp.status_code == 200
+        pairs = resp.get_json()['pairs']
+    assert pairs[0] == ['square1.jpg', 'square2.jpg']
+    assert pairs[1] == ['wide1.jpg', 'wide2.jpg']
+    clear_upload_dir()
+
+
+def test_auto_group_dominant_color(tmp_path):
+    clear_upload_dir()
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    r1 = os.path.join(UPLOAD_DIR, 'r1.jpg')
+    r2 = os.path.join(UPLOAD_DIR, 'r2.jpg')
+    b1 = os.path.join(UPLOAD_DIR, 'b1.jpg')
+    b2 = os.path.join(UPLOAD_DIR, 'b2.jpg')
+    Image.new('RGB', (10, 10), 'red').save(r1)
+    Image.new('RGB', (10, 10), 'red').save(r2)
+    Image.new('RGB', (10, 10), 'blue').save(b1)
+    Image.new('RGB', (10, 10), 'blue').save(b2)
+    with app.test_client() as client:
+        resp = client.post('/auto_group', json={'method': 'dominant_color'})
+        assert resp.status_code == 200
+        pairs = resp.get_json()['pairs']
+    pair_sets = [set(p) for p in pairs]
+    assert set(['r1.jpg', 'r2.jpg']) in pair_sets
+    assert set(['b1.jpg', 'b2.jpg']) in pair_sets
+    clear_upload_dir()
+
+
+def test_auto_group_random(tmp_path):
+    clear_upload_dir()
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    names = ['a.jpg', 'b.jpg', 'c.jpg', 'd.jpg']
+    for name in names:
+        Image.new('RGB', (10, 10), 'white').save(os.path.join(UPLOAD_DIR, name))
+    random.seed(0)
+    with app.test_client() as client, patch('app.os.listdir', return_value=names):
+        resp = client.post('/auto_group', json={'method': 'random'})
+        assert resp.status_code == 200
+        pairs = resp.get_json()['pairs']
+    assert pairs == [['c.jpg', 'a.jpg'], ['b.jpg', 'd.jpg']]
+    clear_upload_dir()
 
 
 def test_preserve_exif_metadata(tmp_path):


### PR DESCRIPTION
## Summary
- support new image pairing modes: aspect ratio, dominant colour, and random
- expose new grouping methods in UI select box
- test grouping algorithms for correctness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec641dadc832299ec32331109c9a0